### PR TITLE
Use `finish` event instead of `complete`

### DIFF
--- a/libs/index.js
+++ b/libs/index.js
@@ -98,7 +98,7 @@ function gPublish(options) {
 
     file.pipe(gcFile.createWriteStream({metadata: metadata}))
         .on('error', done)
-        .on('complete', function() {
+        .on('finish', function() {
           if (options.public) {
             return gcFile.makePublic(function(err) {
               logSuccess(gcPah);

--- a/test/gcloud.spec.js
+++ b/test/gcloud.spec.js
@@ -42,12 +42,7 @@ describe('gulp-gcloud-publish', function() {
     return through(function(chunk, enc, next) {
       this.push(chunk)
       next();
-    })
-    .on('data', function() {})
-    .on('end', function() {
-      this.emit('complete');
     });
-
   }
 
   gcloud.__set__('gcloud', gcloudMock);


### PR DESCRIPTION
[gcloud-node@0.21.0](https://github.com/GoogleCloudPlatform/gcloud-node/releases/tag/v0.21.0) switched from `complete` to `finish` and `end` events to play more nicely with streaming pipelines.
