### PR TITLE
Solved callback pipe problem

### DIFF
--- a/libs/index.js
+++ b/libs/index.js
@@ -97,7 +97,9 @@ function gPublish(options) {
     var gcFile = bucket.file(gcPah);
 
     file.pipe(gcFile.createWriteStream({metadata: metadata}))
-        .on('error', done)
+        .on('error', function(e){
+          throw new PluginError(PLUGIN_NAME, "Error in gcloud connection.\nError message:\n" + JSON.stringify(e));
+        })
         .on('finish', function() {
           if (options.public) {
             return gcFile.makePublic(function(err) {


### PR DESCRIPTION
There is a problem with streaming and the `done()` callback. Larger directories already passed to the next task while still uploading.

By replacing the stream with regular upload, all uploads need to be finished before the latest `done()` is called.

Now -if the user wants Gulp to run synchronously- it will go to the next pipe when files are really _done_ uploading.