### PR TITLE
Use new Google Cloud Storage node client

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ First, you need to create your Google Cloud API credentials. [__Official Docs__]
 The plugin takes a configuration object with the following keys:
 
 - bucket `String`: Name of the bucket where we want to upload the file
+- gzip `Boolean` (optional): Let Google automatically gzip and mark metadata of your file. Regardless of this setting, already-gzipped files will have metadata properly set.
 - keyFilename `String`: Full path to the Google Cloud API keyfile ([docs][gc-docs])
 - projectId `String`: Google Cloud Project ID ([docs][gc-docs])
 - base `String`: base path to use in the bucket, default to `/`
 - public `Boolean` (optional): If set to true, marks the uploaded file as public
+- resumable `Boolean` (optional): Should be set to true for large files (>10Mb). Default is `false`.
 - transformDestination `Function` (optional): Manipulates the final destination of the file in the bucket.
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The plugin takes a configuration object with the following keys:
 - projectId `String`: Google Cloud Project ID ([docs][gc-docs])
 - base `String`: base path to use in the bucket, default to `/`
 - public `Boolean` (optional): If set to true, marks the uploaded file as public
+- transformDestination `Function` (optional): Manipulates the final destination of the file in the bucket.
 
 ## Example
 
@@ -40,7 +41,10 @@ gulp.task('publish', function() {
         keyFilename: 'path/to/keyFile.json',
         projectId: 'my-project-id',
         base: '/css',
-        public: true,        
+        public: true,
+        transformDestination: function(path) {
+          return path.toLowerCase();
+        },
         metadata: {
             cacheControl: 'max-age=315360000, no-transform, public',
         }

--- a/libs/index.js
+++ b/libs/index.js
@@ -103,7 +103,9 @@ function gPublish(options) {
     var uploadOptions = {
       destination: options.transformDestination ? options.transformDestination(gcPath) : gcPath,
       metadata: metadata,
+      gzip: !!options.gzip,
       public: options.public || metadata.contentEncoding === "gzip",
+      resumable: !!options.resumable
     };
 
     file.pipe(

--- a/libs/index.js
+++ b/libs/index.js
@@ -103,7 +103,7 @@ function gPublish(options) {
 
     var uploadOptions = {
       metadata: metadata,
-      public: options.public,
+      public: options.public || metadata.contentEncoding === "gzip",
     };
 
     file.pipe(gcFile.createWriteStream(uploadOptions))

--- a/libs/index.js
+++ b/libs/index.js
@@ -36,11 +36,12 @@ function getMetadata(file, metadata) {
  *
  * @param base - Base path
  * @param file - File to save
+ * @return {string} - new relative path for GCS
  */
 function normalizePath(base, file) {
   var _relative = file.path.replace(file.base, '');
 
-  // ensure there is a tailing slash in the base path
+  // ensure there is a trailing slash in the base path
   if (base && !/\/$/.test(base)) {
     base += '/';
   }
@@ -51,7 +52,10 @@ function normalizePath(base, file) {
   }
 
   base = base || '';
-  return base + _relative;
+
+  var newPath = base + _relative;
+
+  return newPath.replace(/\\/g, "/");
 }
 
 /**
@@ -96,7 +100,7 @@ function gPublish(options) {
 
     var bucket = storage.bucket(options.bucket);
 
-    var gcPath = normalizePath(options.base, file).replace(/\\/g, "/");
+    var gcPath = normalizePath(options.base, file);
 
     var metadata = getMetadata(file, options.metadata);
 
@@ -104,7 +108,7 @@ function gPublish(options) {
       destination: options.transformDestination ? options.transformDestination(gcPath) : gcPath,
       metadata: metadata,
       gzip: !!options.gzip,
-      public: options.public || metadata.contentEncoding === "gzip",
+      public: !!options.public,
       resumable: !!options.resumable
     };
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/albertorestifo/gulp-gcloud-publish#readme",
   "dependencies": {
-    "gcloud": "^0.24.0",
+    "@google-cloud/storage": "^0.7.0",
     "gulp-util": "^3.0.5",
     "mime": "^1.3.4",
     "through2": "^2.0.0"

--- a/test/gcloud.spec.js
+++ b/test/gcloud.spec.js
@@ -13,22 +13,18 @@ var expect = chai.expect;
 chai.should();
 
 /** Tested module */
-var gcloud = rewire('../libs/');
+var gcloudStorage = rewire('../libs/');
 
 describe('gulp-gcloud-publish', function() {
   /** Mock Gcloud */
-  var storageStub = sinon.stub();
+  var gcloudStorageStub = sinon.stub();
   var bucketStub = sinon.stub();
   var fileStub = sinon.stub();
   var createWriteStreamStub = sinon.stub();
 
-  var gcloudMock = {
-    storage: storageStub
-  }
-
   var makePublicCallCount = 0;
 
-  storageStub.returns({bucket: bucketStub});
+  gcloudStorageStub.returns({bucket: bucketStub});
   bucketStub.returns({file: fileStub});
   fileStub.returns({
     createWriteStream: createWriteStreamStub,
@@ -45,7 +41,7 @@ describe('gulp-gcloud-publish', function() {
     });
   }
 
-  gcloud.__set__('gcloud', gcloudMock);
+  gcloudStorage.__set__('gcloudStorage', gcloudStorageStub);
 
   var exampleConfig = {
     bucket: 'something',
@@ -55,13 +51,13 @@ describe('gulp-gcloud-publish', function() {
 
   it('should throw an error when missing configuration object', function() {
     expect(function() {
-          return gcloud()
+          return gcloudStorage()
         }).to.throw(/Missing configuration object/);
   });
 
   it('should throw an error when missing requred parameters', function() {
     function callWith(options) {
-      return function() { return gcloud(options); };
+      return function() { return gcloudStorage(options); };
     }
 
     // missing projectId
@@ -92,7 +88,7 @@ describe('gulp-gcloud-publish', function() {
       path: '/test/file.css'
     });
 
-    var task = gcloud(exampleConfig);
+    var task = gcloudStorage(exampleConfig);
 
     task.write(fakeFile);
     task.on('data', function(file) {
@@ -122,7 +118,7 @@ describe('gulp-gcloud-publish', function() {
     var config = _.clone(exampleConfig);
     config.public = true;
 
-    var task = gcloud(config);
+    var task = gcloudStorage(config);
 
     task.write(fakeFile);
     task.on('data', function(file) {
@@ -150,7 +146,7 @@ describe('gulp-gcloud-publish', function() {
       path: '/test/file.css'
     });
 
-    var task = gcloud(exampleConfig);
+    var task = gcloudStorage(exampleConfig);
 
     task.write(fakeFile);
     task.on('data', function() {
@@ -172,7 +168,7 @@ describe('gulp-gcloud-publish', function() {
 
     var config = _.clone(exampleConfig);
     config.base = '/test';
-    var task = gcloud(config);
+    var task = gcloudStorage(config);
 
     task.write(fakeFile);
     task.on('data', function() {
@@ -194,7 +190,7 @@ describe('gulp-gcloud-publish', function() {
 
     var config = _.clone(exampleConfig);
     config.base = 'test/';
-    var task = gcloud(config);
+    var task = gcloudStorage(config);
 
     task.write(fakeFile);
     task.on('data', function() {
@@ -216,7 +212,7 @@ describe('gulp-gcloud-publish', function() {
 
     var config = _.clone(exampleConfig);
     config.base = '/test/';
-    var task = gcloud(config);
+    var task = gcloudStorage(config);
 
     task.write(fakeFile);
     task.on('data', function() {


### PR DESCRIPTION
Hello,

This PR updates the plugin to use Google's new client for Cloud Storage. They have options to set uploads as resumable or not, and a flag to use their machines to gzip on the fly.

In addition to getting rid of deprecation warnings of the old package, this newer package solves a few bugs that were causing odd 404s and 503s when uploading many small files.

I also added a utility function to transform the file destination string, which has been useful when building on a windows machine.