### PR TITLE
Do not require keyfile or project ID

### DIFF
--- a/libs/index.js
+++ b/libs/index.js
@@ -78,12 +78,8 @@ function logSuccess(gPath) {
  */
 function gPublish(options) {
   // A configuration object is required
-  if (!options) {
-    throw new PluginError(PLUGIN_NAME, 'Missing configuration object!');
-  }
-  // And most of the keys also are
-  if (!options.bucket || !options.keyFilename || !options.projectId) {
-    throw new PluginError(PLUGIN_NAME, 'Missing required configuration params');
+  if (!options || !options.bucket) {
+    throw new PluginError(PLUGIN_NAME, 'Missing required configuration: bucket');
   }
 
   return through.obj(function(file, enc, done) {

--- a/test/gcloud.spec.js
+++ b/test/gcloud.spec.js
@@ -39,14 +39,12 @@ describe('gulp-gcloud-publish', function() {
 
   var exampleConfig = {
     bucket: 'something',
-    projectId: 'some-id',
-    keyFilename: '/path/to/something.json'
   }
 
   it('should throw an error when missing configuration object', function() {
     expect(function() {
           return gcloudStorage()
-        }).to.throw(/Missing configuration object/);
+        }).to.throw(/Missing required configuration/);
   });
 
   it('should throw an error when missing requred parameters', function() {
@@ -54,23 +52,8 @@ describe('gulp-gcloud-publish', function() {
       return function() { return gcloudStorage(options); };
     }
 
-    // missing projectId
-    expect(callWith({
-      bucket: true,
-      keyFilename: true
-    })).to.throw(/Missing required configuration params/);
-
-    // missing keyFilename
-    expect(callWith({
-      bucket: true,
-      projectId: true
-    })).to.throw(/Missing required configuration params/);
-
     // missing bucket
-    expect(callWith({
-      projectId: true,
-      keyFilename: true
-    })).to.throw(/Missing required configuration params/);
+    expect(callWith({})).to.throw(/Missing required configuration/);
   });
 
   it('should set the correct metadata', function(done) {


### PR DESCRIPTION
Both of these values can be inferred by the underlying client library. When running on GCP, the authentication happens automagically through service accounts attached to the instances/functions.