### PR TITLE
Return on null file

### DIFF
--- a/libs/index.js
+++ b/libs/index.js
@@ -88,7 +88,9 @@ function gPublish(options) {
 
   return through.obj(function(file, enc, done) {
     /* istanbul ignore next */
-    if (file.isNull()) { done(null, file); }
+    if (file.isNull()) {
+      return done(null, file);
+    }
 
     file.path = file.path.replace(/\.gz$/, '');
 


### PR DESCRIPTION
Without the return, this will call the callback twice, resulting in error